### PR TITLE
Don't end Vulkan render pass for volatile buffers in CommandList::writeBuffer

### DIFF
--- a/src/vulkan/vulkan-buffer.cpp
+++ b/src/vulkan/vulkan-buffer.cpp
@@ -418,8 +418,6 @@ namespace nvrhi::vulkan
 
         assert(m_CurrentCmdBuf);
 
-        endRenderPass();
-
         m_CurrentCmdBuf->referencedResources.push_back(buffer);
 
         if (buffer->desc.isVolatile)
@@ -430,6 +428,10 @@ namespace nvrhi::vulkan
             
             return;
         }
+
+        // Per Vulkan spec, vkCmdUpdateBuffer is only allowed outside of a render pass, so end it here.
+        // Note that writeVolatileBuffer above is permitted so don't end the render pass for that case.
+        endRenderPass();
 
         const size_t vkCmdUpdateBufferLimit = 65536;
 


### PR DESCRIPTION
(cherry picked from commit f22894e57b24b111541238c2aafabf8bf3c2f9a3)

This fixes a long-standing performance problem on macOS with volatile constant buffers.  The change https://github.com/NVIDIA-RTX/NVRHI/pull/99 was merged into Nvidia's main today.

I don't necessarily expect you to merge this since RBDoom3BFG is frozen, but I wanted to you to see it for your own use or possibly other projects.  I wish I had found this earlier, but it came out of a discussion I had with the KosmicKrisp developers and later with Alexey Panteleev.